### PR TITLE
add region to assume role

### DIFF
--- a/lib/assume-role-source.ts
+++ b/lib/assume-role-source.ts
@@ -206,7 +206,15 @@ export class AssumeRoleCredentialProviderSource implements cdk.CredentialProvide
    * Try to assume the specified role and return the credentials or undefined
    */
   private async tryAssumeRole(roleArn: string, accountId: string): Promise<AWS.STS.Credentials | undefined> {
-    const sts = new AWS.STS({credentials: await this.defaultCredentials()});
+    
+    const region = this.config && this.config.settings && this.config.settings.get(["context"]).region;
+
+    region && AWS.config.update({ region });
+
+    const sts = new AWS.STS({
+      credentials: await this.defaultCredentials(),  ...(region && { region }),
+    });
+ 
     let response: AWS.STS.Credentials | undefined;
     try {
       const resp = await sts.assumeRole({


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
When region context isn't provided the role is assumed without a specified region, causing an error. 

Allow region to be passed if given in context 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
