### PR TITLE
fix: replace minus with hyphen

### DIFF
--- a/cdk-sample-pipelines-app/README.md
+++ b/cdk-sample-pipelines-app/README.md
@@ -83,12 +83,12 @@ The role is also configured to trust the Shared Services account.
 
 1. Using CLI credentials for the Dev AWS Account, run cdk deploy to create the resources
 ```bash
-$ cdk deploy –-app "npx ts-node bin/required-resources.ts" dev
+$ cdk deploy --app "npx ts-node bin/required-resources.ts" dev
 ```
 
 2. Using CLI credentials for the Prod AWS Account, run cdk deploy to create the resources
 ```bash
-$ cdk deploy –-app "npx ts-node bin/required-resources.ts" prod
+$ cdk deploy --app "npx ts-node bin/required-resources.ts" prod
 ```
 
 Now you should have the required roles created in both the Dev and Prod AWS Accounts.


### PR DESCRIPTION
*Description of changes:*

cdk option should be declared by hyphen, not minus symbol.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
