### PR TITLE
feat: load aws_default_ environment variables

### DIFF
--- a/lib/assume-role-source.ts
+++ b/lib/assume-role-source.ts
@@ -211,6 +211,14 @@ export class AssumeRoleCredentialProviderSource implements cdk.CredentialProvide
     }).load();
 
     logging.setLogLevel(yargs.argv.verbose as number)
+
+    // Set environment variables so JS AWS SDK behaves as close as possible to AWS CLI.
+    if (process.env.AWS_DEFAULT_PROFILE && !process.env.AWS_PROFILE) {
+      process.env.AWS_PROFILE = process.env.AWS_DEFAULT_PROFILE;
+    }
+    if (process.env.AWS_DEFAULT_REGION && !process.env.AWS_REGION) {
+      process.env.AWS_REGION = process.env.AWS_DEFAULT_REGION;
+    }
   }
 
   /**


### PR DESCRIPTION
now use the aws_default_region and aws_default_profile environment variables if aws_region and aws_profile are not set. This aligns with the functionality of the aws-cdk.

fix #42
fix #31

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
