### PR TITLE
reorder credential provider chain

### DIFF
--- a/lib/assume-role-source.ts
+++ b/lib/assume-role-source.ts
@@ -232,12 +232,12 @@ export class AssumeRoleCredentialProviderSource implements cdk.CredentialProvide
     const profile = this.config.settings.get(['profile']);
     const masterCreds = new AWS.CredentialProviderChain([
       function () { return new AWS.ECSCredentials(); },
-      function () { return new AWS.SharedIniFileCredentials({ profile: profile }); },
-      function () { return new AWS.TokenFileWebIdentityCredentials(); },
-      function () { return new AWS.ProcessCredentials({ profile: profile }); },
       function () { return new AWS.EnvironmentCredentials('AWS'); },
       function () { return new AWS.EnvironmentCredentials('AMAZON'); },
-      function () { return new AWS.EC2MetadataCredentials(); },
+      function () { return new AWS.SharedIniFileCredentials({ profile: profile }); },
+      function () { return new AWS.ProcessCredentials({ profile: profile }); },
+      function () { return new AWS.TokenFileWebIdentityCredentials(); },
+      function () { return new AWS.EC2MetadataCredentials() },
     ]);
     return masterCreds.resolvePromise();
   }


### PR DESCRIPTION
*Issue #58*

*Description of changes:*

change the order of the provider chain to stick as close as possible to the default chain (https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html#defaultProviders-property)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
